### PR TITLE
feat: [PIDM-504] update deploy config

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.69.0
 appVersion: 0.0.10
 dependencies:
   - name: microservice-chart
-    version: 7.5.0
+    version: 8.0.2
     repository: "https://pagopa.github.io/aks-microservice-chart-blueprint"

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -20,9 +20,14 @@ microservice-chart:
     initialDelaySeconds: 90
     failureThreshold: 6
     periodSeconds: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   deployment:
     create: true
-    replicas: 1
+    replicas: 1 # same as HPA minReplica
   service:
     create: true
     type: ClusterIP

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -20,14 +20,14 @@ microservice-chart:
     initialDelaySeconds: 90
     failureThreshold: 6
     periodSeconds: 10
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 0
-      maxSurge: 1
   deployment:
     create: true
     replicas: 1 # same as HPA minReplica
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 0
+        maxSurge: 1
   service:
     create: true
     type: ClusterIP

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -20,9 +20,14 @@ microservice-chart:
     initialDelaySeconds: 90
     failureThreshold: 6
     periodSeconds: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   deployment:
     create: true
-    replicas: 1
+    replicas: 1 # same as HPA minReplica
   service:
     create: true
     type: ClusterIP

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -20,14 +20,14 @@ microservice-chart:
     initialDelaySeconds: 90
     failureThreshold: 6
     periodSeconds: 10
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 0
-      maxSurge: 1
   deployment:
     create: true
     replicas: 1 # same as HPA minReplica
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 0
+        maxSurge: 1
   service:
     create: true
     type: ClusterIP

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -20,9 +20,14 @@ microservice-chart:
     initialDelaySeconds: 90
     failureThreshold: 6
     periodSeconds: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   deployment:
     create: true
-    replicas: 1
+    replicas: 1 # same as HPA minReplica
   service:
     create: true
     type: ClusterIP

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -20,14 +20,14 @@ microservice-chart:
     initialDelaySeconds: 90
     failureThreshold: 6
     periodSeconds: 10
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 0
-      maxSurge: 1
   deployment:
     create: true
     replicas: 1 # same as HPA minReplica
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 0
+        maxSurge: 1
   service:
     create: true
     type: ClusterIP


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- migrated helm chart to v8.0.2
- added rolling update strategy (maxUnavailable, maxSurge)

NOTE: upgraded in

- DEV -> OK
- UAT -> OK
- PROD -> OK

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

This upgrade was required to address an issue with the rollout strategy and the autoscaler behaviour, where the pods would scale down to 1 during deploy instead of keeping the same number of pods and doing +1 -1 to avoid traffic congestion.
This also ensures zero-downtime deployments by keeping all existing pods running until new versions are healthy and ready, then replacing them one at a time.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

```
❯ kubectl get scaledobject pagopa-stand-in-technical-support-microservice-chart -n nodo -o jsonpath='{.metadata.labels.helm\.sh/blueprint-version}' && echo
7.5.0
```
```
❯   kubectl get scaledobject pagopa-stand-in-technical-support-microservice-chart -n nodo -o jsonpath='{.metadata.annotations.helm\.sh/hook}' && echo " (has hooks)" || echo " (no hooks or doesn't exist)"
post-install ,post-upgrade (has hooks)
```
```
❯   kubectl delete scaledobject pagopa-stand-in-technical-support-microservice-chart -n nodo
scaledobject.keda.sh "pagopa-stand-in-technical-support-microservice-chart" deleted from nodo namespace
```

```
❯ helm dependency update
Getting updates for unmanaged Helm repositories...
...Successfully got an update from the "https://pagopa.github.io/aks-microservice-chart-blueprint" chart repository
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "bitnami" chart repository
Update Complete. ⎈Happy Helming!⎈
Saving 1 charts
Downloading microservice-chart from repo https://pagopa.github.io/aks-microservice-chart-blueprint
Deleting outdated charts
```

```
❯ helm upgrade --namespace nodo \
      --install --values ./values-dev.yaml \
      --set microservice-chart.azure.workloadIdentityClientId=919f4844-xxxxx \
      --set microservice-chart.podAnnotations.force-rollout="rollout-$(date +%s)" \
      --wait --timeout 15m0s \
      pagopa-stand-in-technical-support .
Release "pagopa-stand-in-technical-support" has been upgraded. Happy Helming!
NAME: pagopa-stand-in-technical-support
LAST DEPLOYED: Fri Oct 17 15:31:30 2025
NAMESPACE: nodo
STATUS: deployed
REVISION: 10
TEST SUITE: None
```

```
❯ kubectl get scaledobject pagopa-stand-in-technical-support-microservice-chart -n nodo -o jsonpath='{.metadata}' | jq '{labels: .labels, annotations: .annotations}'
{
  "labels": {
    "app.kubernetes.io/instance": "pagopa-stand-in-technical-support",
    "app.kubernetes.io/managed-by": "Helm",
    "app.kubernetes.io/name": "microservice-chart",
    "app.kubernetes.io/version": "0.0.10",
    "azure.workload.identity/use": "true",
    "canaryDelivery": "false",
    "helm.sh/blueprint-version": "8.0.2",
    "helm.sh/chart": "microservice-chart-0.0.10",
    "scaledobject.keda.sh/name": "pagopa-stand-in-technical-support-microservice-chart"
  },
  "annotations": {
    "meta.helm.sh/release-name": "pagopa-stand-in-technical-support",
    "meta.helm.sh/release-namespace": "nodo"
  }
}
```

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
